### PR TITLE
added setTorqueLimit

### DIFF
--- a/src/AX12A.cpp
+++ b/src/AX12A.cpp
@@ -586,6 +586,29 @@ int AX12A::setAngleLimit(unsigned char ID, int CWLimit, int CCWLimit)
 	return (sendAXPacket(packet, length));
 }
 
+int AX12A::setTorqueLimit(unsigned char ID, int TorqueLimit) {
+	char TorqueLimit_H,TorqueLimit_L;
+    TorqueLimit_H = TorqueLimit >> 8;           // 16 bits - 2 x 8 bits variables
+    TorqueLimit_L = TorqueLimit;
+    
+	const unsigned int length = 9;
+	unsigned char packet[length];
+
+	Checksum = (~(ID + AX_MT_LENGTH + AX_WRITE_DATA + AX_TORQUE_LIMIT_L + TorqueLimit_L + TorqueLimit_H)) & 0xFF;
+
+	packet[0] = AX_START;
+	packet[1] = AX_START;
+	packet[2] = ID;
+	packet[3] = AX_MT_LENGTH;
+	packet[4] = AX_WRITE_DATA;
+	packet[5] = AX_TORQUE_LIMIT_L;
+	packet[6] = TorqueLimit_L;
+	packet[7] = TorqueLimit_H;
+	packet[8] = Checksum;
+	
+	return (sendAXPacket(packet, length));
+}
+
 int AX12A::setMaxTorque(unsigned char ID, int MaxTorque)
 {
     char MaxTorque_H,MaxTorque_L;

--- a/src/AX12A.h
+++ b/src/AX12A.h
@@ -171,6 +171,7 @@ public:
 	int setTempLimit(unsigned char ID, unsigned char Temperature);
 	int setAngleLimit(unsigned char ID, int CWLimit, int CCWLimit);
 	int setVoltageLimit(unsigned char ID, unsigned char DVoltage, unsigned char UVoltage);
+	int setTorqueLimit(unsigned char ID, int TorqueLimit);
 	int setMaxTorque(unsigned char ID, int MaxTorque);
 	int setSRL(unsigned char ID, unsigned char SRL);
 	int setRDT(unsigned char ID, unsigned char RDT);


### PR DESCRIPTION
Use `setTorqueLimit(motorId, 1023)` to revive AX12A after error. Now you dont have to power off servo to make it alive again.